### PR TITLE
Fixed the long compile command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ fc-cache fv
 
 3. Compile the project:
 ```bash
-g++ -o wxTED \
+g++ -std=c++17 -o wxTED \
     -I./include \
     charchange.cpp \
     hamm.c \
@@ -70,9 +70,8 @@ g++ -o wxTED \
     wxTEDMain.cpp \
     src/T42.cpp \
     src/HeaderPacket.cpp \
-    ttxpageset.cpp \    
-    `wx-config --cxxflags --libs core,base,adv,html` \
-    -std=c++17
+    ttxpageset.cpp \
+    $(wx-config --cxxflags --libs core,base,adv,html)
 ```
 
 4. Run wxTED:


### PR DESCRIPTION
The old version gave alot of errors like these:
```
charchange.h:9:10: fatal error: wx/gdicmn.h: No such file or directory
    9 | #include "wx/gdicmn.h"
      |          ^~~~~~~~~~~~~
compilation terminated.
-bash: -I/usr/lib/x86_64-linux-gnu/wx/include/gtk3-unicode-3.2: No such file or directory
```
The new version fixes those issues :)